### PR TITLE
fix: 🐛 Fixed android video timing issue (#2)

### DIFF
--- a/android/src/main/java/com/example/ivs_broadcaster/IvsPlayerView.java
+++ b/android/src/main/java/com/example/ivs_broadcaster/IvsPlayerView.java
@@ -145,7 +145,7 @@ public class IvsPlayerView extends Player.Listener implements PlatformView, Surf
                 result.success(true);
                 break;
             case "position":
-                result.success(player.getPosition());
+                result.success(millisToSeconds(player.getPosition()));
                 break;
             case "qualities":
                 List<String> qualities = getQualities();
@@ -254,7 +254,7 @@ public class IvsPlayerView extends Player.Listener implements PlatformView, Surf
     @Override
     public void onDurationChanged(long l) {
         HashMap<String, Object> data = new HashMap<>();
-        data.put("duration", l);
+        data.put("duration", millisToSeconds(l));
         sendEvent(data);
     }
 
@@ -295,5 +295,9 @@ public class IvsPlayerView extends Player.Listener implements PlatformView, Surf
         HashMap<String, Object> data = new HashMap<>();
         data.put("quality", quality.getName());
         sendEvent(data);
+    }
+
+    public long millisToSeconds(long millis) {
+        return millis / 1000;
     }
 }


### PR DESCRIPTION
- Time was in milliseconds in Android and we are expecting seconds, which caused duration and position to be incorrect. 
This will fix the issue, so could you please review this PR.

Closes #2 